### PR TITLE
Fix: README.md fix image url

### DIFF
--- a/spring-Ingress-Readme.md
+++ b/spring-Ingress-Readme.md
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
       - name: springappsample2
-        image: dbin887742/springappsample2:v1
+        image: {docker_hub_id}/{spring_app_img_name}:v1
         ports:
         - containerPort: 8080
 
@@ -141,7 +141,7 @@ kubectl get svc
 
 | 용어          | 설명 |
 |---------------|------------------------------------------------|
-| containerPort | 컨테이너 내부에서 앱이 실제로 사용하는 포트 (기본 8080) |
+| containerPort | 컨테이너 내부에서 앱이 실제로 사용하는 포트 |
 | targetPort    | Service → Pod 간 트래픽 전달 포트 |
 | port          | Cluster 내부에서 Service가 노출하는 포트 |
 | nodePort      | 외부 접근 가능 포트 (30000~32767 범위) |
@@ -184,7 +184,7 @@ spec:
     spec:
       containers:
       - name: springappsample2
-        image: dbin887742/springappsample2:v1
+        image: {docker_hub_id}/{spring_app_img_name}:v1
         ports:
         - containerPort: 8080
 


### PR DESCRIPTION
Updated image reference to use placeholders for Docker Hub ID and image name.